### PR TITLE
docs: fix typo in Introduction section of introduction page

### DIFF
--- a/full-kit/src/app/(unlocalized)/docs/overview/introduction/page.mdx
+++ b/full-kit/src/app/(unlocalized)/docs/overview/introduction/page.mdx
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the documentation for **Shadboard**, aan open-source admin dashboard template built with **Next.js** and **Shadcn/ui** components for scalable, user-friendly web apps. It's free for the community to use, learn from, and contribute to.
+Welcome to the documentation for **Shadboard**, an open-source admin dashboard template built with **Next.js** and **Shadcn/ui** components for scalable, user-friendly web apps. It's free for the community to use, learn from, and contribute to.
 
 Shadboard leverages the powerful **Shadcn/ui** component library, **Tailwind CSS 4**, and the latest technologies such as **React 19**, **Next.js 15**, and **TypeScript** to ensure a highly efficient, flexible, and user-friendly experience. For more details on the Shadcn/ui component library, visit [Shadcn/ui](https://ui.shadcn.com/).
 


### PR DESCRIPTION
This PR fixes a small typo in the Introduction page (overview > introduction > page.mdx):
Changed “aan open-source” to “an open-source”.

Closes #35