### PR TITLE
refactor: update documentation layout borders and remove Separator

### DIFF
--- a/full-kit/src/app/(unlocalized)/docs/_components/docs-header.tsx
+++ b/full-kit/src/app/(unlocalized)/docs/_components/docs-header.tsx
@@ -7,7 +7,7 @@ import { ToggleMobileSidebar } from "./toggle-mobile-sidebar"
 
 export function DocsHeader() {
   return (
-    <header className="sticky top-0 w-full bg-background z-50">
+    <header className="sticky top-0 w-full bg-background z-50 border-b">
       <div className="container flex justify-between items-center gap-2 p-4">
         <Link href="/docs" className="inline-flex text-foreground font-black">
           <Image

--- a/full-kit/src/app/(unlocalized)/docs/_components/docs-sidebar.tsx
+++ b/full-kit/src/app/(unlocalized)/docs/_components/docs-sidebar.tsx
@@ -30,7 +30,10 @@ export function DocsSidebar() {
   const { openMobile, setOpenMobile, isMobile } = useSidebar()
 
   return (
-    <SidebarWrapper className="sticky top-[4.25rem] h-svh" collapsible="none">
+    <SidebarWrapper
+      className="sticky top-[4.25rem] h-svh border-e border-sidebar-border"
+      collapsible="none"
+    >
       <SidebarHeader className={openMobile && isMobile ? "" : "hidden"}>
         <Link
           href="/"

--- a/full-kit/src/app/(unlocalized)/docs/_components/toc.tsx
+++ b/full-kit/src/app/(unlocalized)/docs/_components/toc.tsx
@@ -151,7 +151,7 @@ export function TableOfContents({ items }: TableOfContentsProps) {
   return (
     <aside
       className={cn(
-        "shrink-0 sticky top-[4.25rem] h-svh w-(--sidebar-width) hidden bg-background",
+        "shrink-0 sticky top-[4.25rem] h-svh w-(--sidebar-width) hidden bg-background border-s border-sidebar-border",
         !isMobile && "block"
       )}
     >

--- a/full-kit/src/app/(unlocalized)/docs/layout.tsx
+++ b/full-kit/src/app/(unlocalized)/docs/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { ReactNode } from "react"
 
-import { Separator } from "@/components/ui/separator"
 import { DocsBreadcrumb } from "./_components/docs-breadcrumb"
 import { DocsHeader } from "./_components/docs-header"
 import { DocsPagination } from "./_components/docs-pagination"
@@ -21,8 +20,7 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
       <DocsHeader />
       <div className="relative grid lg:grid-cols-[auto_1fr_auto]">
         <DocsSidebar />
-        <main className="grid bg-muted/40 border-x border-b border-sidebar-border">
-          <Separator className="sticky z-50 top-[4.25rem] hidden w-full h-[0.5px] md:block" />
+        <main className="grid bg-muted/40">
           <div className="justify-self-center p-4 z-10">
             <DocsBreadcrumb />
             <div


### PR DESCRIPTION
## Description

This PR addresses the layout inconsistency mentioned in issue #33. The documentation page header was missing a bottom border, causing it to look different from other pages and also added the mentioned changes.

Closes #33