### PR TITLE
fix: correct spelling of "cairo" in font variables and usage

### DIFF
--- a/full-kit/src/app/[lang]/(dashboard-layout)/(design-system)/typography/_data/font-families.ts
+++ b/full-kit/src/app/[lang]/(dashboard-layout)/(design-system)/typography/_data/font-families.ts
@@ -1,7 +1,7 @@
 export const fontFamiliesData = [
   {
     name: "Cairo",
-    class: "font-cario",
+    class: "font-cairo",
     language: "Arabic",
     example: "مرحبا بالعالم",
   },

--- a/full-kit/src/app/[lang]/layout.tsx
+++ b/full-kit/src/app/[lang]/layout.tsx
@@ -39,7 +39,7 @@ const cairoFont = Cairo({
   subsets: ["arabic"],
   weight: ["400", "700"],
   style: ["normal"],
-  variable: "--font-cario",
+  variable: "--font-cairo",
 })
 
 export default async function RootLayout(props: {
@@ -57,7 +57,7 @@ export default async function RootLayout(props: {
     <html lang={params.lang} dir={direction} suppressHydrationWarning>
       <body
         className={cn(
-          "[&:lang(en)]:font-lato [&:lang(ar)]:font-cario", // Set font styles based on the language
+          "[&:lang(en)]:font-lato [&:lang(ar)]:font-cairo", // Set font styles based on the language
           "bg-background text-foreground antialiased overscroll-none", // Set background, text, , anti-aliasing styles, and overscroll behavior
           latoFont.variable, // Include Lato font variable
           cairoFont.variable // Include Cairo font variable

--- a/full-kit/src/app/globals.css
+++ b/full-kit/src/app/globals.css
@@ -9,8 +9,8 @@
   --font-lato:
     var(--font-lato), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-cario:
-    var(--font-cario), ui-sans-serif, system-ui, sans-serif,
+  --font-cairo:
+    var(--font-cairo), ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --color-border: hsl(var(--border));

--- a/starter-kit/src/app/globals.css
+++ b/starter-kit/src/app/globals.css
@@ -8,8 +8,8 @@
   --font-lato:
     var(--font-lato), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-cario:
-    var(--font-cario), ui-sans-serif, system-ui, sans-serif,
+  --font-cairo:
+    var(--font-cairo), ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --color-border: hsl(var(--border));

--- a/starter-kit/src/app/layout.tsx
+++ b/starter-kit/src/app/layout.tsx
@@ -35,7 +35,7 @@ const cairoFont = Cairo({
   subsets: ["arabic"],
   weight: ["400", "700"],
   style: ["normal"],
-  variable: "--font-cario",
+  variable: "--font-cairo",
 })
 
 export default function RootLayout(props: { children: ReactNode }) {
@@ -45,7 +45,7 @@ export default function RootLayout(props: { children: ReactNode }) {
     <html lang="en" dir="ltr" suppressHydrationWarning>
       <body
         className={cn(
-          "[&:lang(en)]:font-lato [&:lang(ar)]:font-cario", // Set font styles based on the language
+          "[&:lang(en)]:font-lato [&:lang(ar)]:font-cairo", // Set font styles based on the language
           "bg-background text-foreground antialiased overscroll-none", // Set background, text, , anti-aliasing styles, and overscroll behavior
           latoFont.variable, // Include Lato font variable
           cairoFont.variable // Include Cairo font variable


### PR DESCRIPTION
Closes #67 