### PR TITLE
fix(contextual-classes): contrast-issue-in-rows

### DIFF
--- a/full-kit/src/app/[lang]/(dashboard-layout)/(design-system)/tables/_components/tables/contextual-classes.tsx
+++ b/full-kit/src/app/[lang]/(dashboard-layout)/(design-system)/tables/_components/tables/contextual-classes.tsx
@@ -13,9 +13,9 @@ import {
 } from "@/components/ui/table"
 
 const statusClasses: Record<InvoiceType["status"], string> = {
-  Paid: "bg-green-100 hover:bg-green-200",
-  Pending: "bg-yellow-100 hover:bg-yellow-200",
-  Overdue: "bg-red-100 hover:bg-red-200",
+  Paid: "bg-green-100 text-green-700 hover:bg-green-200",
+  Pending: "bg-yellow-100 text-yellow-700 hover:bg-yellow-200",
+  Overdue: "bg-red-100 text-red-700 hover:bg-red-200",
 }
 
 export default function ContextualClasses() {


### PR DESCRIPTION
Closes #70 

This PR fixes a UI bug where text inside table rows with background colors had low contrast

![image](https://github.com/user-attachments/assets/30c13fef-c1f5-464f-94c7-10bae6fed9a1)
