### PR TITLE
fix: editor bold resets text color & Ctrl+B toggles sidebar

### DIFF
--- a/full-kit/src/components/ui/editor/index.tsx
+++ b/full-kit/src/components/ui/editor/index.tsx
@@ -45,7 +45,7 @@ export function Editor({
     editorProps: {
       attributes: {
         class: cn(
-          "px-3 py-2 break-all [&_p]:m-0 [&_.is-editor-empty]:before:absolute [&_.is-editor-empty]:before:top-2 [&_.is-editor-empty]:before:cursor-text [&_.is-editor-empty]:before:text-muted-foreground [&_.is-editor-empty]:before:content-[attr(data-placeholder)] prose prose-headings:font-normal prose-headings:text-foreground prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg dark:prose-invert focus:outline-hidden",
+          "px-3 py-2 break-all [&_p]:m-0 [&_.is-editor-empty]:before:absolute [&_.is-editor-empty]:before:top-2 [&_.is-editor-empty]:before:cursor-text [&_.is-editor-empty]:before:text-muted-foreground [&_.is-editor-empty]:before:content-[attr(data-placeholder)] prose prose-headings:font-normal prose-headings:text-foreground prose-strong:text-inherit prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg dark:prose-invert focus:outline-hidden",
           className
         ),
       },

--- a/full-kit/src/components/ui/sidebar.tsx
+++ b/full-kit/src/components/ui/sidebar.tsx
@@ -107,6 +107,9 @@ export function SidebarProvider({
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
         (event.metaKey || event.ctrlKey)
       ) {
+        // Don't toggle sidebar when inside a contenteditable element (e.g., rich text editor)
+        if ((event.target as HTMLElement)?.isContentEditable) return
+
         event.preventDefault()
         toggleSidebar()
       }


### PR DESCRIPTION
## Summary
- **Bold strips text color**: Tailwind's `prose` class applies its own `color` to `<strong>` elements, overriding the inherited inline color from the parent `<span style="color: ...">`. Fixed by adding `prose-strong:text-inherit` so bold text inherits the color set by the color picker.
- **Ctrl+B toggles sidebar**: The sidebar's global `keydown` handler catches `Ctrl+B` even when focus is inside the rich text editor. Fixed by skipping the handler when `event.target` is a `contentEditable` element.

Closes #76

## Test plan
- [ ] Open the editor at `/extended-ui/editor`
- [ ] Pick a text color, type some text, select it, press Ctrl+B — text should become bold while keeping the color
- [ ] Press Ctrl+B inside the editor — sidebar should NOT toggle
- [ ] Press Ctrl+B outside the editor (e.g. on the dashboard) — sidebar should still toggle normally